### PR TITLE
Feature/state mutations

### DIFF
--- a/src/resolvers/__tests__/set-group-state.test.js
+++ b/src/resolvers/__tests__/set-group-state.test.js
@@ -1,5 +1,4 @@
 import Color from 'hue-colors';
-import nock from 'nock';
 
 import { query, bridge, createGroup } from '../../test-utils';
 

--- a/src/resolvers/__tests__/set-group-state.test.js
+++ b/src/resolvers/__tests__/set-group-state.test.js
@@ -1,0 +1,65 @@
+import Color from 'hue-colors';
+import nock from 'nock';
+
+import { query, bridge, createGroup } from '../../test-utils';
+
+jest.mock('../../../bridge.json');
+
+describe('Group state mutation', () => {
+  let get, put, group, spy;
+
+  beforeEach(() => {
+    group = createGroup({ id: 28 });
+    spy = jest.fn(() => ({ fake: true }));
+
+    get = bridge.get('/groups/28').reply(200, group);
+    put = bridge.put('/groups/28/action').reply(200, spy);
+  });
+
+  afterEach(() => {
+    get.done();
+    put.done();
+  });
+
+  it('sets the group state', async () => {
+    const { hue } = await query`mutation {
+      hue {
+        group: setGroupState(id: 28 state: { on: true }) { allOn }
+      }
+    }`;
+
+    expect(hue.group).toEqual({ allOn: group.state.all_on });
+    expect(spy).toHaveBeenCalledWith(expect.any(String), JSON.stringify({
+      on: true,
+    }));
+  });
+
+  it('sets the transition time', async () => {
+    await query`mutation {
+      hue {
+        setGroupState(id: 28 state: { transition: 1000, on: true }) { anyOn }
+      }
+    }`;
+
+    expect(spy).toHaveBeenCalled();
+    const [, json] = spy.mock.calls[0];
+
+    expect(JSON.parse(json)).toEqual({
+      transitiontime: 10,
+      on: true,
+    });
+  });
+
+  it('supports color mutations', async () => {
+    await query`mutation {
+      hue {
+        setGroupState(id: 28 state: { color: "#0000ff" }) { color }
+      }
+    }`;
+
+    const [, json] = spy.mock.calls[0];
+    const [hue, sat, bri] = Color.fromHex('#0000ff').toHsb();
+
+    expect(JSON.parse(json)).toEqual({ hue, sat, bri });
+  });
+});

--- a/src/resolvers/__tests__/set-light-state.test.js
+++ b/src/resolvers/__tests__/set-light-state.test.js
@@ -1,0 +1,64 @@
+import { query, bridge, createLight } from '../../test-utils';
+import mutation from '../../utils/state-mutations';
+
+jest.mock('../../../bridge.json');
+
+describe('Light state mutation', () => {
+  let get, put, spy, light;
+
+  beforeEach(() => {
+    light = createLight({ on: true });
+    spy = jest.fn(() => ({ fake: true }));
+
+    put = bridge.put('/lights/10/state').reply(200, spy);
+    get = bridge.get('/lights/10').reply(200, light);
+  });
+
+  afterEach(() => {
+    get.done();
+    put.done();
+  });
+
+  it('sets the light state', async () => {
+    await query`mutation {
+      hue {
+        setLightState(id: 10 state: { on: false }) { on }
+      }
+    }`;
+
+    expect(spy).toHaveBeenCalled();
+    const [, json] = spy.mock.calls[0];
+
+    expect(JSON.parse(json)).toEqual({ on: false });
+  });
+
+  it('supports transition time', async () => {
+    await query`mutation {
+      hue {
+        setLightState(id: 10 state: { transition: 2000, on: true }) { on }
+      }
+    }`;
+
+    const [, json] = spy.mock.calls[0];
+
+    expect(JSON.parse(json)).toEqual({
+      transitiontime: 20,
+      on: true,
+    });
+  });
+
+  it('supports colors', async () => {
+    await query`mutation {
+      hue {
+        setLightState(id: 10 state: { on: true, color: "#00aaff" }) { on }
+      }
+    }`;
+
+    const [, json] = spy.mock.calls[0];
+
+    expect(JSON.parse(json)).toEqual({
+      ...mutation({ color: '#00aaff' }),
+      on: true,
+    });
+  });
+});

--- a/src/resolvers/hue-resolvers.js
+++ b/src/resolvers/hue-resolvers.js
@@ -3,3 +3,5 @@ export { default as light } from './light';
 
 export { default as groups } from './groups';
 export { default as lights } from './lights';
+
+export { default as setGroupState } from './set-group-state';

--- a/src/resolvers/hue-resolvers.js
+++ b/src/resolvers/hue-resolvers.js
@@ -5,3 +5,4 @@ export { default as groups } from './groups';
 export { default as lights } from './lights';
 
 export { default as setGroupState } from './set-group-state';
+export { default as setLightState } from './set-light-state';

--- a/src/resolvers/set-group-state.js
+++ b/src/resolvers/set-group-state.js
@@ -1,0 +1,42 @@
+import invariant from 'invariant';
+import Color from 'hue-colors';
+
+import group from './group';
+
+const hexCodeValidator = /[0-9a-fA-F]/;
+const isValidHexCharacter = hexCodeValidator.test.bind(hexCodeValidator);
+
+/**
+ * Ensures a hex color code is valid.
+ * @param  {String} color - CSS hex color code.
+ * @throws {Error} - If any check fails.
+ * @return {void}
+ */
+const validateColor = (color) => {
+  invariant(color[0] === '#', 'Invalid hex code, expected a hash symbol.');
+  invariant(color.length === 7, 'Expected a 6-digit hex color code.');
+
+  const isValidHexCode = color.slice(1).split('').every(isValidHexCharacter);
+  invariant(isValidHexCode, `Invalid color code: ${color}`);
+};
+
+export default async (args, context) => {
+  const { transition, color, ...patch } = args.state;
+
+  // Hue measures transition times in multiples of 100ms.
+  if (transition) {
+    patch.transitiontime = transition / 100;
+  }
+
+  // Turn hex codes into something Hue understands.
+  if (color) {
+    validateColor(color);
+    const [hue, sat, bri] = Color.fromHex(color.toLowerCase()).toHsb();
+    Object.assign(patch, { hue, sat, bri });
+  }
+
+  // Pull the lever, Kronk!
+  await context.hue.put(`groups/${args.id}/action`, patch);
+
+  return group({ id: args.id }, context);
+};

--- a/src/resolvers/set-group-state.js
+++ b/src/resolvers/set-group-state.js
@@ -1,39 +1,8 @@
-import invariant from 'invariant';
-import Color from 'hue-colors';
-
+import mutation from '../utils/state-mutations';
 import group from './group';
 
-const hexCodeValidator = /[0-9a-fA-F]/;
-const isValidHexCharacter = hexCodeValidator.test.bind(hexCodeValidator);
-
-/**
- * Ensures a hex color code is valid.
- * @param  {String} color - CSS hex color code.
- * @throws {Error} - If any check fails.
- * @return {void}
- */
-const validateColor = (color) => {
-  invariant(color[0] === '#', 'Invalid hex code, expected a hash symbol.');
-  invariant(color.length === 7, 'Expected a 6-digit hex color code.');
-
-  const isValidHexCode = color.slice(1).split('').every(isValidHexCharacter);
-  invariant(isValidHexCode, `Invalid color code: ${color}`);
-};
-
 export default async (args, context) => {
-  const { transition, color, ...patch } = args.state;
-
-  // Hue measures transition times in multiples of 100ms.
-  if (transition) {
-    patch.transitiontime = transition / 100;
-  }
-
-  // Turn hex codes into something Hue understands.
-  if (color) {
-    validateColor(color);
-    const [hue, sat, bri] = Color.fromHex(color.toLowerCase()).toHsb();
-    Object.assign(patch, { hue, sat, bri });
-  }
+  const patch = mutation(args.state);
 
   // Pull the lever, Kronk!
   await context.hue.put(`groups/${args.id}/action`, patch);

--- a/src/resolvers/set-light-state.js
+++ b/src/resolvers/set-light-state.js
@@ -1,0 +1,10 @@
+import mutation from '../utils/state-mutations';
+import light from './light';
+
+export default async (args, context) => {
+  const patch = mutation(args.state);
+
+  await context.hue.put(`lights/${args.id}/state`, patch);
+
+  return light({ id: args.id }, context);
+};

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -55,3 +55,17 @@ type Hue {
 type Query {
   hue: Hue
 }
+
+input GroupState {
+  transition: Int
+  color: String
+  on: Boolean
+}
+
+type HueMutations {
+  setGroupState(id: ID! state: GroupState!): LightGroup
+}
+
+type Mutation {
+  hue: HueMutations
+}

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -56,14 +56,15 @@ type Query {
   hue: Hue
 }
 
-input GroupState {
+input LightState {
   transition: Int
   color: String
   on: Boolean
 }
 
 type HueMutations {
-  setGroupState(id: ID! state: GroupState!): LightGroup
+  setGroupState(id: ID! state: LightState!): LightGroup
+  setLightState(id: ID! state: LightState!): Light
 }
 
 type Mutation {

--- a/src/utils/__tests__/__snapshots__/state-mutations.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/state-mutations.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`State mutation handles the hex code correctly 1`] = `
+Object {
+  "bri": 254,
+  "hue": 0,
+  "sat": 0,
+}
+`;

--- a/src/utils/__tests__/state-mutations.test.js
+++ b/src/utils/__tests__/state-mutations.test.js
@@ -1,0 +1,60 @@
+import Color from 'hue-colors';
+
+import mutation from '../state-mutations';
+
+describe('State mutation', () => {
+  it('passes through unrecognized props', () => {
+    const data = { on: true, potato: 'enabled', things: 1.28 };
+    const result = mutation(data);
+
+    expect(result).toEqual(data);
+  });
+
+  it('replaces transitions with the hue equivalent', () => {
+    const result = mutation({ transition: 1000, on: false });
+
+    expect(result).toEqual({ transitiontime: 10, on: false });
+  });
+
+  it('formats color', () => {
+    const color = '#FF00FF';
+    const result = mutation({ color, on: true });
+
+    const [hue, sat, bri] = Color.fromHex('ff00ff').toHsb();
+
+    expect(result).toEqual({ hue, sat, bri, on: true });
+  });
+
+  it('throws if the hash symbol is omitted', () => {
+    const fail = () => mutation({ color: 'ffffff' });
+
+    expect(fail).toThrow(/(hash|#)/i);
+  });
+
+  it('throws if the color length is unexpected', () => {
+    const fail = () => mutation({ color: '#1234567' });
+
+    expect(fail).toThrow(/length/);
+    expect(fail).toThrow(/7/);
+  });
+
+  it('throws if the color characters are invalid', () => {
+    const fail = () => mutation({ color: '#0agz%.' });
+
+    expect(fail).toThrow(/character/i);
+  });
+
+  it('handles the hex code correctly', () => {
+    const result = mutation({ color: '#ffffff' });
+
+    expect(result.hue).toEqual(expect.any(Number));
+    expect(result.sat).toEqual(expect.any(Number));
+    expect(result.bri).toEqual(expect.any(Number));
+
+    expect(isNaN(result.hue)).toBe(false);
+    expect(isNaN(result.sat)).toBe(false);
+    expect(isNaN(result.bri)).toBe(false);
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/src/utils/state-mutations.js
+++ b/src/utils/state-mutations.js
@@ -1,0 +1,32 @@
+import invariant from 'invariant';
+import Color from 'hue-colors';
+
+const hexValidator = /^#[0-9a-f]{6}$/i;
+
+const normalizeHexColor = (color) => {
+  const hex = color.toLowerCase();
+
+  invariant(hex[0] === '#', 'Invalid hex code, missing the hash symbol (#)');
+  invariant(hex.length === 7, `Hex code length is invalid (${hex.length - 1})`);
+  invariant(hexValidator.test(hex), `Invalid characters in hex code (${hex})`);
+
+  return hex.slice(1);
+};
+
+export default (mutation) => {
+  const { transition, color, ...patch } = mutation;
+
+  // Transitions are multiples of 100ms.
+  if (typeof transition === 'number') {
+    patch.transitiontime = transition / 100;
+  }
+
+  // Turn hex codes into hue-friendly HSB.
+  if (typeof color === 'string') {
+    const hex = normalizeHexColor(color);
+    const [hue = 0, sat, bri] = Color.fromHex(hex).toHsb();
+    Object.assign(patch, { hue, sat, bri });
+  }
+
+  return patch;
+};


### PR DESCRIPTION
Adds two mutations: `setLightState` and `setGroupState`. Both do entirely what you'd expect.

```graphql
mutation {
  hue {
    setGroupState(id: 4 state: {
      on: true
      color: "#ff00aa"
    }) {
      color name lights { name color }
    }
  }
}
```