### PR TITLE
Add scene endpoint

### DIFF
--- a/src/resolvers/__tests__/scenes.test.js
+++ b/src/resolvers/__tests__/scenes.test.js
@@ -1,0 +1,95 @@
+import { query, bridge, createScenes, createLight } from '../../test-utils';
+
+describe('Scenes resolver', () => {
+  let scenes, endpoint;
+
+  beforeEach(() => {
+    scenes = createScenes();
+    endpoint = bridge.get('/scenes').reply(200, scenes);
+  });
+
+  afterEach(() => {
+    endpoint.done();
+  });
+
+  it('works', async () => {
+    const result = await query`{
+      hue {
+        scenes {
+          id
+        }
+      }
+    }`;
+
+    expect(result.hue.scenes).toEqual(expect.any(Array));
+    expect(result.hue.scenes.length).toBeGreaterThan(0);
+  });
+
+  it('contains each scene ID', async () => {
+    const result = await query`{
+      hue {
+        scenes {
+          id
+        }
+      }
+    }`;
+
+    const [id] = Object.keys(scenes);
+    expect(result.hue.scenes).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: id })]),
+    );
+  });
+
+  it('formats all the data', async () => {
+    const result = await query`{
+      hue {
+        scenes {
+          id name owner locked version recycle lastUpdated
+        }
+      }
+    }`;
+
+    const [id] = Object.keys(scenes);
+    const { name, owner, recycle, locked, version } = scenes[id];
+    expect(result.hue.scenes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          lastUpdated: scenes[id].lastupdated,
+          recycle,
+          version,
+          locked,
+          owner,
+          name,
+        }),
+      ]),
+    );
+  });
+
+  it('resolves light data when requested', async () => {
+    const endpoints = [
+      bridge.get('/lights/41').reply(200, createLight()),
+      bridge.get('/lights/42').reply(200, createLight()),
+    ];
+
+    const result = await query`{
+      hue {
+        scenes {
+          lights { id name }
+        }
+      }
+    }`;
+
+    expect(result.hue.scenes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          lights: [
+            { id: '41', name: 'Light name' },
+            { id: '42', name: 'Light name' },
+          ],
+        }),
+      ]),
+    );
+
+    endpoints.forEach(endpoint => endpoint.done());
+  });
+});

--- a/src/resolvers/hue-resolvers.js
+++ b/src/resolvers/hue-resolvers.js
@@ -4,5 +4,7 @@ export { default as light } from './light';
 export { default as groups } from './groups';
 export { default as lights } from './lights';
 
+export { default as scenes } from './scenes';
+
 export { default as setGroupState } from './set-group-state';
 export { default as setLightState } from './set-light-state';

--- a/src/resolvers/scenes.js
+++ b/src/resolvers/scenes.js
@@ -1,0 +1,31 @@
+import resolveLight from './light';
+
+/** Represents a Hue scene */
+class Scene {
+  /**
+   * @param  {String} id - Scene ID.
+   * @param  {Object} data - Scene data.
+   */
+  constructor(id, { lights, lastupdated, ...scene }) {
+    this._lights = lights;
+
+    Object.assign(this, { id, lastUpdated: lastupdated, ...scene });
+  }
+
+  /**
+   * Fetches the full data of each light.
+   * @param  {Object} args - None accepted.
+   * @param  {Object} context - Request context.
+   * @param  {Object} info - GraphQL AST request info.
+   * @return {Promise[]} - The request for each light.
+   */
+  lights(args, context, info) {
+    return this._lights.map(id => resolveLight({ id }, context, info));
+  }
+}
+
+export default async (args, context) => {
+  const response = await context.hue.get('scenes');
+
+  return Object.keys(response).map(id => new Scene(id, response[id]));
+};

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -40,12 +40,28 @@ type Light {
   uniqueId: ID
 }
 
+type Scene {
+  # Lights affected by the scene.
+  lights: [Light]
+  # Human friendly scene title.
+  name: String
+  # False if the scene can be deleted. Otherwise, it's in use
+  # by a schedule or sensor.
+  locked: Boolean
+  owner: String
+  recycle: Boolean
+  lastUpdated: String
+  version: Int
+  id: ID
+}
+
 # Queries for reading the state of hue lights.
 type Hue {
   group(id: ID!): LightGroup
   light(id: ID!): Light
   groups: [LightGroup]
   lights: [Light]
+  scenes: [Scene]
 }
 
 type Query {

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -66,16 +66,17 @@ export const createGroup = (fields = {}) => ({
 });
 
 export const createScenes = (fields = {}) => ({
-  HtUI2PPXPcsEPUt: {
-    name: 'Fall Colors',
-    lights: ['41', '42'],
+  KseUksCEskA9Al2: {
     owner: 'kn82nNLskEnks208Nla32LnLkndaekuDNKnsnks8',
+    lastupdated: '2017-10-30T02:10:46',
+    appdata: { version: 1 },
+    lights: ['41', '42'],
+    name: 'Fall Colors',
     recycle: false,
     locked: false,
-    appdata: { version: 1, data: 'U1o81_r04_d99' },
     picture: '',
-    lastupdated: '2017-10-30T02:10:46',
     version: 2,
   },
+
   ...fields,
 });

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -64,3 +64,18 @@ export const createGroup = (fields = {}) => ({
 
   ...fields,
 });
+
+export const createScenes = (fields = {}) => ({
+  HtUI2PPXPcsEPUt: {
+    name: 'Fall Colors',
+    lights: ['41', '42'],
+    owner: 'kn82nNLskEnks208Nla32LnLkndaekuDNKnsnks8',
+    recycle: false,
+    locked: false,
+    appdata: { version: 1, data: 'U1o81_r04_d99' },
+    picture: '',
+    lastupdated: '2017-10-30T02:10:46',
+    version: 2,
+  },
+  ...fields,
+});


### PR DESCRIPTION
Gets the full set of scenes. It doesn't contain all the data yet, and
querying lights is prohibitively expensive (waaaay too many requests).
The next project will likely be implementing Dataloader (response
caching).

Anyway, here's what the new endpoint looks like:

```graphql
query {
  hue {
    scenes {
      id name
    }
  }
}
```