### PR TITLE
Add response caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "change-case": "^3.0.1",
+    "dataloader": "^1.3.0",
     "express": "^4.15.4",
     "express-graphql": "^0.6.7",
     "graphql": "^0.10.5",

--- a/src/context.js
+++ b/src/context.js
@@ -1,3 +1,4 @@
+import Dataloader from 'dataloader';
 import invariant from 'invariant';
 import fetch from 'node-fetch';
 
@@ -45,56 +46,65 @@ const checkResultsForErrors = results => {
   return results;
 };
 
-export const hue = {
-  /**
-   * GET request to hue.
-   * @param  {String} [path] - Relative URL path.
-   * @return {Promise<Object>} - HTTP response.
-   */
-  get: async path => {
-    const url = huerl(path);
-
-    const response = await fetch(url);
-    const json = await response.json();
-
-    return checkResultsForErrors(json);
-  },
-
-  /**
-   * PUT request to hue.
-   * @param  {String} [path] - Relative URL path.
-   * @param  {Object} patch - JSON data.
-   * @return {Promise<Object>} - HTTP response.
-   */
-  put: async (path, patch) => {
-    const url = huerl(path);
-
-    const response = await fetch(url, {
-      body: JSON.stringify(patch),
-      method: 'PUT',
+export const createHueLoaders = () => {
+  const loader = new Dataloader(urls => {
+    const requests = urls.map(async url => {
+      const response = await fetch(url);
+      return response.json();
     });
 
-    const json = await response.json();
+    return Promise.all(requests);
+  });
 
-    return checkResultsForErrors(json);
-  },
+  return {
+    /**
+     * GET request to hue.
+     * @param  {String} [path] - Relative URL path.
+     * @return {Promise<Object>} - HTTP response.
+     */
+    get: async path => {
+      const url = huerl(path);
+      const json = await loader.load(url);
 
-  /**
-   * POST request to hue.
-   * @param  {String} [path] - Relative URL path.
-   * @param  {Object} data - JSON data.
-   * @return {Promise<Object>} - HTTP response.
-   */
-  post: async (path, data) => {
-    const url = huerl(path);
+      return checkResultsForErrors(json);
+    },
 
-    const response = await fetch(url, {
-      body: JSON.stringify(data),
-      method: 'POST',
-    });
+    /**
+     * PUT request to hue.
+     * @param  {String} [path] - Relative URL path.
+     * @param  {Object} patch - JSON data.
+     * @return {Promise<Object>} - HTTP response.
+     */
+    put: async (path, patch) => {
+      const url = huerl(path);
 
-    const json = await response.json();
+      const response = await fetch(url, {
+        body: JSON.stringify(patch),
+        method: 'PUT',
+      });
 
-    return checkResultsForErrors(json);
-  },
+      const json = await response.json();
+
+      return checkResultsForErrors(json);
+    },
+
+    /**
+     * POST request to hue.
+     * @param  {String} [path] - Relative URL path.
+     * @param  {Object} data - JSON data.
+     * @return {Promise<Object>} - HTTP response.
+     */
+    post: async (path, data) => {
+      const url = huerl(path);
+
+      const response = await fetch(url, {
+        body: JSON.stringify(data),
+        method: 'POST',
+      });
+
+      const json = await response.json();
+
+      return checkResultsForErrors(json);
+    },
+  };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import express from 'express';
 import schema from './schema';
 import rc from 'rc';
 
-import * as context from './context';
+import { createHueLoaders } from './context';
 import rootValue from './resolvers';
 
 const config = rc('filament', {
@@ -12,12 +12,12 @@ const config = rc('filament', {
   port: 8080,
 });
 
-const graphqlEndpoint = graphqlHttp({
+const graphqlEndpoint = graphqlHttp(() => ({
+  context: { hue: createHueLoaders() },
   graphiql: config.graphiql === true,
   rootValue,
-  context,
   schema,
-});
+}));
 
 const app = express();
 app.use(graphqlEndpoint);

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,14 +1,16 @@
 import { graphql } from 'graphql';
 import nock from 'nock';
 
-import * as context from './context';
+import { createHueLoaders, huerl } from './context';
 import resolvers from './resolvers';
 import schema from './schema';
 
-export const bridge = nock(context.huerl());
+export const bridge = nock(huerl());
 
 export const query = async ([request]) => {
-  const response = await graphql(schema, request, resolvers, context);
+  const response = await graphql(schema, request, resolvers, {
+    hue: createHueLoaders(),
+  });
 
   expect(response.errors).toBeUndefined();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,6 +989,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+dataloader@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.3.0.tgz#6fec5be4b30a712e4afd30b86b4334566b97673b"
+
 date-fns@^1.27.2:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"


### PR DESCRIPTION
Responses from the server are cached using `Dataloader`. Caches survive
only as long as the GraphQL query, so there's no risk of accidental
stale data.

This makes the `scenes {lights {name}}` query case not only possible,
but quick. It could be improved further by requesting every light ahead
of time and priming the cache, but the performance isn't necessary yet.