### PR TITLE
Feature/schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ npm start
 - :x: Get a Luminaire Group's unique ID
 
 ### Schedules
-- :x: Get a Schedule by ID
-- :x: Get all Schedules
+- :white_check_mark: Get a Schedule by ID
+- :white_check_mark: Get all Schedules <span style="font-size: 0.8em;">[\[3\]](#notes)</span>
 
 ### Scenes
 - :white_check_mark: Get a Scene by ID
@@ -142,6 +142,8 @@ npm start
 \[1\]: The alert state provided by the Hue API contains the last alert sent to the light and not its current state (i.e. whether an alert is active), so this isn't particularly useful.
 
 \[2\]: Deleting lights [can be messy](https://developers.meethue.com/documentation/delete-devices-application-guidance) and we haven't needed it, so we haven't added this yet.
+
+\[3\]: Due to some limitations of GraphQL, the `schedule.command.body` field isn't exposed yet.
 
 ## Disclaimer
 I'm not affiliated with Philips in any way. I'm just a guy on the internet playing with code :heart:

--- a/src/resolvers/__tests__/schedule.test.js
+++ b/src/resolvers/__tests__/schedule.test.js
@@ -1,0 +1,35 @@
+import { query, bridge, createSchedule } from '../../test-utils';
+
+describe('Schedule resolver', () => {
+  let endpoint, schedule;
+
+  beforeEach(() => {
+    schedule = createSchedule();
+    endpoint = bridge.get('/schedules/8').reply(200, schedule);
+  });
+
+  afterEach(() => endpoint.done());
+
+  it('works', async () => {
+    const result = await query`{
+      schedule(id: "8") {
+        name
+      }
+    }`;
+
+    expect(result.schedule).not.toBe(null);
+  });
+
+  it('includes the ID', async () => {
+    const result = await query`{
+      schedule(id: "8") {
+        name id
+      }
+    }`;
+
+    expect(result.schedule).toEqual({
+      name: schedule.name,
+      id: '8',
+    });
+  });
+});

--- a/src/resolvers/__tests__/schedules.test.js
+++ b/src/resolvers/__tests__/schedules.test.js
@@ -1,0 +1,70 @@
+import { query, bridge, createSchedules } from '../../test-utils';
+
+describe('Schedules resolver', () => {
+  let endpoint, schedules;
+
+  beforeEach(() => {
+    schedules = createSchedules();
+    endpoint = bridge.get('/schedules').reply(200, schedules);
+  });
+
+  afterEach(() => endpoint.done());
+
+  it('works', async () => {
+    const { schedules } = await query`{
+      schedules {
+        name
+      }
+    }`;
+
+    expect(schedules).toEqual(expect.any(Array));
+    expect(schedules).toHaveLength(Object.keys(schedules).length);
+  });
+
+  it('includes the ID', async () => {
+    const result = await query`{
+      schedules {
+        id
+      }
+    }`;
+
+    const expected = Object.keys(schedules).map(id =>
+      expect.objectContaining({ id }),
+    );
+
+    expect(result.schedules).toEqual(expect.arrayContaining(expected));
+  });
+
+  it('formats the data correctly', async () => {
+    const result = await query`{
+      schedules {
+        localTime name time description recycle status created
+      }
+    }`;
+
+    const [id] = Object.keys(schedules);
+    const {
+      localtime,
+      name,
+      time,
+      description,
+      recycle,
+      status,
+      created,
+    } = schedules[id];
+
+    expect(result.schedules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          localTime: localtime,
+          description,
+          created,
+          recycle,
+          status,
+          name,
+          time,
+        }),
+      ]),
+    );
+  });
+});

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,6 +1,7 @@
 export { default as group } from './group';
 export { default as light } from './light';
 export { default as scene } from './scene';
+export { default as schedule } from './schedule';
 
 export { default as groups } from './groups';
 export { default as lights } from './lights';

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -5,6 +5,7 @@ export { default as scene } from './scene';
 export { default as groups } from './groups';
 export { default as lights } from './lights';
 export { default as scenes } from './scenes';
+export { default as schedules } from './schedules';
 
 export { default as setGroupState } from './set-group-state';
 export { default as setLightState } from './set-light-state';

--- a/src/resolvers/schedule.js
+++ b/src/resolvers/schedule.js
@@ -1,0 +1,10 @@
+/** Hue scheduled action (e.g., alarms). */
+export class Schedule {
+  /**
+   * @param  {String} id - Schedule ID.
+   * @param  {Object} schedule - Data returned from the REST API.
+   */
+  constructor(id, { localtime, ...schedule }) {
+    Object.assign(this, schedule, { id, localTime: localtime });
+  }
+}

--- a/src/resolvers/schedule.js
+++ b/src/resolvers/schedule.js
@@ -8,3 +8,9 @@ export class Schedule {
     Object.assign(this, schedule, { id, localTime: localtime });
   }
 }
+
+export default async (args, context) => {
+  const schedule = await context.hue.get(`schedules/${args.id}`);
+
+  return new Schedule(args.id, schedule);
+};

--- a/src/resolvers/schedules.js
+++ b/src/resolvers/schedules.js
@@ -1,0 +1,7 @@
+import { Schedule } from './schedule';
+
+export default async (args, context) => {
+  const schedules = await context.hue.get('schedules');
+
+  return Object.keys(schedules).map(id => new Schedule(id, schedules[id]));
+};

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -115,6 +115,7 @@ type Query {
   scene(id: ID!): Scene
   scenes: [Scene]
   schedules: [Schedule]
+  schedule(id: ID!): Schedule
 }
 
 input LightState {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -79,13 +79,30 @@ type Scene {
   id: ID
 }
 
+enum ScheduleStatus {
+  enabled
+  disabled
+}
+
+type Schedule {
+  status: ScheduleStatus
+  description: String
+  localTime: String
+  recycle: Boolean
+  created: String
+  name: String
+  time: String
+  id: ID
+}
+
 type Query {
   group(id: ID!): LightGroup
-  light(id: ID!): Light
-  scene(id: ID!): Scene
   groups: [LightGroup]
+  light(id: ID!): Light
   lights: [Light]
+  scene(id: ID!): Scene
   scenes: [Scene]
+  schedules: [Schedule]
 }
 
 input LightState {

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -79,12 +79,24 @@ type Scene {
   id: ID
 }
 
+enum HttpMethod {
+  DELETE
+  POST
+  PUT
+}
+
+type ScheduleCommand {
+  method: HttpMethod
+  address: String
+}
+
 enum ScheduleStatus {
   enabled
   disabled
 }
 
 type Schedule {
+  command: ScheduleCommand
   status: ScheduleStatus
   description: String
   localTime: String

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -87,3 +87,27 @@ export const createScenes = fields => ({
 
   ...fields,
 });
+
+export const createSchedule = fields => ({
+  created: '2017-10-31T13:45:56',
+  localtime: 'W124/T07:45:00',
+  description: 'MyRoutine',
+  time: 'W124/T13:45:00',
+  name: 'Morning Alarm',
+  status: 'enabled',
+  recycle: true,
+  command: {
+    address: '/api/t0k3n/groups/11/state',
+    body: { on: true },
+    method: 'PUT',
+  },
+
+  ...fields,
+});
+
+export const createSchedules = fields => ({
+  1: createSchedule(),
+  2: createSchedule(),
+
+  ...fields,
+});


### PR DESCRIPTION
Adds two new endpoints, `schedule(id: 5)` and `schedules {...}`. You can probably guess the rest.

I'm leaving one part of schedules omitted because it's technically challenging. The `body` is what's posted to the endpoint when the schedule fires, but it's an untyped mess. It's either an object with set fields (requiring a type definition for every permutation of a post request in the API and knowledge of which one it is at runtime) or implementing a new json scalar type (which doesn't play nicely with `buildSchema`).

Right now I'm masterfully procrastinating because it sounds like a problem for tomorrow me.