### PR TITLE
Feature/precaching

### DIFF
--- a/src/__tests__/context.test.js
+++ b/src/__tests__/context.test.js
@@ -212,4 +212,13 @@ describe('Hue http', () => {
       ]);
     });
   });
+
+  describe('precache', () => {
+    it('uses cache for later requests to the same url', async () => {
+      const response = { cached: 'response' };
+      hue.precache('lights/', response);
+
+      await expect(hue.get('lights/')).resolves.toEqual(response);
+    });
+  });
 });

--- a/src/context.js
+++ b/src/context.js
@@ -148,5 +148,18 @@ export const createHueLoaders = () => {
      * @return {Object} - Request counts, timing, etc.
      */
     getRequestStats: () => clone(stats),
+
+    /**
+     * Primes the dataloader cache.
+     * @param  {String} url - A url to precache.
+     * @param  {any} response - Response data to use (typically json).
+     * @return {void}
+     * @example
+     * lights.forEach(light =>
+     *   context.precache(`lights/${light.id}`, light))
+     */
+    precache: (url, response) => {
+      loader.prime(url, response);
+    },
   };
 };

--- a/src/resolvers/__tests__/group.test.js
+++ b/src/resolvers/__tests__/group.test.js
@@ -38,7 +38,7 @@ describe('Group resolver', () => {
     const group = createGroup({ lights: [1] });
     const light = createLight();
     endpoint = bridge.get('/groups/15').reply(200, group);
-    const lightEndpoint = bridge.get('/lights/1').reply(200, light);
+    const lightEndpoint = bridge.get('/lights').reply(200, { 1: light });
 
     const result = await query`{
       group(id: 15) {

--- a/src/resolvers/__tests__/scene.test.js
+++ b/src/resolvers/__tests__/scene.test.js
@@ -26,10 +26,10 @@ describe('Scene resolver', () => {
   });
 
   it('resolves light data when requested', async () => {
-    const endpoints = [
-      bridge.get('/lights/41').reply(200, createLight()),
-      bridge.get('/lights/42').reply(200, createLight()),
-    ];
+    const endpoint = bridge.get('/lights').reply(200, {
+      41: createLight(),
+      42: createLight(),
+    });
 
     const result = await query`{
       scene(id: "KseUksCEskA9Al2") {
@@ -42,6 +42,6 @@ describe('Scene resolver', () => {
       { id: '42', name: 'Light name' },
     ]);
 
-    endpoints.forEach(endpoint => endpoint.done());
+    endpoint.done();
   });
 });

--- a/src/resolvers/group.js
+++ b/src/resolvers/group.js
@@ -1,5 +1,6 @@
 /* eslint-disable require-jsdoc */
 import toHexColorCode, { BLACK } from '../utils/color';
+import { prefetchLights } from '../utils/prefetch';
 import resolveLight from './light';
 
 export class LightGroup {
@@ -20,6 +21,7 @@ export class LightGroup {
   }
 
   async lights(args, context) {
+    await prefetchLights(context);
     const requests = this.raw.lights.map(id => resolveLight({ id }, context));
 
     return Promise.all(requests);

--- a/src/resolvers/scene.js
+++ b/src/resolvers/scene.js
@@ -1,3 +1,4 @@
+import { prefetchLights } from '../utils/prefetch';
 import resolveLight from './light';
 
 /** Represents a Hue scene */
@@ -19,7 +20,9 @@ export class Scene {
    * @param  {Object} info - GraphQL AST request info.
    * @return {Promise[]} - The request for each light.
    */
-  lights(args, context, info) {
+  async lights(args, context, info) {
+    await prefetchLights(context);
+
     return this._lights.map(id => resolveLight({ id }, context, info));
   }
 }

--- a/src/utils/__tests__/prefetch.test.js
+++ b/src/utils/__tests__/prefetch.test.js
@@ -1,0 +1,41 @@
+import { createLight } from '../../test-utils';
+import { prefetchLights } from '../prefetch';
+
+describe('prefetchLights', () => {
+  let context;
+
+  beforeEach(() => {
+    context = {
+      hue: {
+        get: jest.fn(() => ({})),
+        precache: jest.fn(),
+      },
+    };
+  });
+
+  it('requests all lights', async () => {
+    await prefetchLights(context);
+
+    expect(context.hue.get).toHaveBeenCalledWith('lights');
+  });
+
+  it('precaches every light', async () => {
+    const lights = Array(10)
+      .fill()
+      .map(() => createLight());
+
+    const response = lights.reduce((lights, light, id) => {
+      lights[id] = light;
+      return lights;
+    }, {});
+
+    context.hue.get.mockReturnValue(response);
+
+    await prefetchLights(context);
+
+    expect(context.hue.precache).toHaveBeenCalledTimes(lights.length);
+    lights.forEach((light, id) =>
+      expect(context.hue.precache).toHaveBeenCalledWith(`lights/${id}`, light),
+    );
+  });
+});

--- a/src/utils/prefetch.js
+++ b/src/utils/prefetch.js
@@ -1,0 +1,14 @@
+/**
+ * Fetches all lights from the bridge and primes the
+ * dataloader cache, making bulk light requests more efficient.
+ * @param  {Object} context - The GQL context.
+ * @return {Promise<void>} - Resolves when finished.
+ */
+export const prefetchLights = async context => {
+  const lights = await context.hue.get('lights');
+
+  for (const [id, light] of Object.entries(lights)) {
+    const url = `lights/${id}`;
+    context.hue.precache(url, light);
+  }
+};


### PR DESCRIPTION
Hue seems to have changed how they handle concurrent requests. Some queries make it choke, like requesting all the lights under every group (even though requests are deduplicated):

```graphql
query {
  groups {
    name
    lights {
      name
    }
  }
}
```

This also caused a bunch of performance trouble for `scenes {...}`, but it was tolerable in the past. Now the queries fail completely.

This PR implements some precaching. Instead of requesting every light individually, it gets the full light set and pulls requests from the cache instead, giving a nice speed boost to some pretty common queries.